### PR TITLE
Archive: Fix getPersonList bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -61,7 +61,7 @@ public class ArchiveCommand extends Command {
         assert resultMessages.size() == targetIndices.size();
 
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredPersonList(lastShownPredicate.and(Model.PREDICATE_SHOW_UNARCHIVED_PERSONS));
+        model.updateFilteredPersonList(lastShownPredicate);
 
         if (resultMessages.size() == 1) {
             return new CommandResult(String.format(MESSAGE_ARCHIVE_PERSON_SUCCESS, resultMessages.get(0)));

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -60,7 +60,7 @@ public class UnarchiveCommand extends Command {
         assert resultMessages.size() == targetIndices.size();
 
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredPersonList(lastShownListPredicate.and(Model.PREDICATE_SHOW_ARCHIVED_PERSONS));
+        model.updateFilteredPersonList(lastShownListPredicate);
 
         if (resultMessages.size() == 1) {
             return new CommandResult(String.format(MESSAGE_UNARCHIVE_PERSON_SUCCESS, resultMessages.get(0)));

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -122,6 +122,11 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         Person personToArchive = internalList.get(index);
+
+        if (personToArchive.isArchived()) {
+            return;
+        }
+
         personToArchive.setArchived(true);
     }
 
@@ -141,6 +146,11 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         Person personToArchive = internalList.get(index);
+
+        if (!personToArchive.isArchived()) {
+            return;
+        }
+
         personToArchive.setArchived(false);
     }
 


### PR DESCRIPTION
Currently, unarchiving persons in the main list and archiving persons in the archive list will lead to a blank page, this is tdue to the bug in the updateFilterList of the ArchiveCommand and Unarchive Command class.

Fix #246 