### PR TITLE
Fix bug when data file is edited

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,6 +41,7 @@ public class LogicManager implements Logic {
         this.storage = storage;
         addressBookParser = new AddressBookParser();
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_UNARCHIVED_PERSONS);
+        model.sortByPin();
     }
 
     @Override


### PR DESCRIPTION
When the pinned parameter in the data file is manually edited, it does not correctly place them at the top of the contact list on start up. This PR fixes that.